### PR TITLE
fix: Update package name in the read me

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ General Typescript ESLint Rules I use.
 
 To use in your project:
 ```
-yarn add git+https://github.com/adiwajshing/eslint
+yarn add git+https://github.com/adiwajshing/eslint-config
 ```
 
 Then create an `.eslintrc.json` like (can also be a yaml or js):


### PR DESCRIPTION
Repo name seems updated, but the README still shows the old one.